### PR TITLE
change the name of the font attribute

### DIFF
--- a/smartfontslib/src/main/java/fr/arnaudguyon/smartfontslib/FontManager.java
+++ b/smartfontslib/src/main/java/fr/arnaudguyon/smartfontslib/FontManager.java
@@ -90,7 +90,7 @@ public class FontManager {
         if (attrs != null) {
             Context context = textView.getContext();
             TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.TextView, 0, 0);
-            String fontPath = styledAttributes.getString(R.styleable.TextView_font);
+            String fontPath = styledAttributes.getString(R.styleable.TextView_smart_font);
             if (!TextUtils.isEmpty(fontPath)) {
                 Typeface typeface = getTypeface(context, fontPath);
                 if (typeface != null) {

--- a/smartfontslib/src/main/res/values/attrs.xml
+++ b/smartfontslib/src/main/res/values/attrs.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <declare-styleable name="TextView">
-        <attr name="font" format="string" />
+        <attr name="smart_font" format="string" />
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
change the name of the font attribute from font to smart_font because it seems to collide with an already defined "font" attribute in build tools 26